### PR TITLE
fix(iframe): #LOOL-86 add allow property to iframe and specify server url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ rev-manifest.json
 node_modules
 /src/main/resources/public/template/entcore/
 /coverage/front/cobertura-coverage.xml
+/package-lock.json

--- a/deployment/lool/conf.json.template
+++ b/deployment/lool/conf.json.template
@@ -1,5 +1,5 @@
     {
-      "name": "fr.openent~lool~1.1.0",
+      "name": "fr.openent~lool~1.1-SNAPSHOT",
       "config": {
         "main" : "fr.openent.lool.Lool",
         "port" : 8333,

--- a/src/main/java/fr/openent/lool/controller/LoolController.java
+++ b/src/main/java/fr/openent/lool/controller/LoolController.java
@@ -96,6 +96,7 @@ public class LoolController extends ControllerHelper {
                                             .put("redirection", event.right().getValue())
                                             .put("document-id", token.getDocument())
                                             .put("access-token", token.getId())
+                                            .put("server", wopiConfig.server().toString())
                                             .put("resync", request.params().contains("resync") ? request.getParam("resync") : false)
                                             .put("provider-name",Wopi.getInstance().provider().type())
                                             .put("duration-token",duration_token + ts.getTime());

--- a/src/main/resources/view-src/doc.html
+++ b/src/main/resources/view-src/doc.html
@@ -26,6 +26,7 @@
         </form>
 
         <iframe id="adapter" class="adapter" name="loleafletframe_viewer"
+                allow="sync-xhr '{{server}}'"
                 allowFullScreen="true"
                 style="z-index:500; position: absolute;height: calc(100% - 64px);width:100%; top: 64px;"></iframe>
         <portal>


### PR DESCRIPTION
## Describe your changes
The ticket asked for adding a security property on iframe tag of lool module. This property (allow=sync xht + serveurURL) specify CORS allowed with this server.
## Checklist tests
Go to workspace and edit a textFile, F12 in LOOL window and look for iframe allow property, check the specified URL.
## Issue ticket number and link
[LOOL-86](https://jira.support-ent.fr/browse/LOOL-86)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

